### PR TITLE
added 'get-prop' mode

### DIFF
--- a/src/property.c
+++ b/src/property.c
@@ -803,6 +803,52 @@ set_float_prop(Display *dpy, int argc, char** argv, char* n, char *desc)
     return do_set_prop(dpy, float_atom, 32, argc, argv, n, desc);
 }
 
+int get_prop(Display *dpy, int argc, char *argv[], char *name,
+	     char *desc)
+{
+    XDeviceInfo *info;
+    XDevice     *dev;
+    Atom         prop;
+    int          rc = EXIT_SUCCESS;
+    int          i = 1;
+
+    if(argc < 2)
+    {
+        fprintf(stderr, "Usage: xinput %s %s\n", name, desc);
+        return EXIT_FAILURE;
+    }
+
+    info = find_device_info(dpy, argv[0], False);
+    if (!info)
+    {
+	fprintf(stderr, "unable to find device '%s'\n", argv[0]);
+	return EXIT_FAILURE;
+    }
+
+    dev = XOpenDevice(dpy, info->id);
+    if (!dev)
+    {
+	fprintf(stderr, "unable to open device '%s'\n", info->name);
+	return EXIT_FAILURE;
+    }
+
+    printf("Device '%s':\n", info->name);
+    while(i < argc) {
+	prop = parse_atom(dpy, argv[i]);
+	if (prop == None) {
+	    fprintf(stderr, "invalid property '%s'\n", name);
+            rc = EXIT_FAILURE;
+	    continue;
+	}
+
+	print_property(dpy, dev, prop);
+	i++;
+    }
+
+    XCloseDevice(dpy, dev);
+    return rc;
+}
+
 int set_prop(Display *display, int argc, char *argv[], char *name,
              char *desc)
 {

--- a/src/xinput.c
+++ b/src/xinput.c
@@ -133,6 +133,10 @@ static entry drivers[] =
       "<device> <property>",
       delete_prop
     },
+    { "get-prop",
+      "<device> <property> [<property> ...]",
+      get_prop
+    },
     { "set-prop",
       "<device> [--type=atom|float|int] [--format=8|16|32] <property> <val> [<val> ...]",
       set_prop

--- a/src/xinput.h
+++ b/src/xinput.h
@@ -68,6 +68,7 @@ int set_float_prop( Display* display, int argc, char *argv[], char *prog_name, c
 int set_atom_prop( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);
 int watch_props( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);
 int delete_prop( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);
+int get_prop( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);
 int set_prop( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);
 int disable( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);
 int enable( Display* display, int argc, char *argv[], char *prog_name, char *prog_desc);


### PR DESCRIPTION
Motivations:
1. have a way to check the property names we pass in advance of calling set-(*-)prop or delete-prop.
2. just generally have a way to get specific property values, rather than only having list-props.